### PR TITLE
Updated Article Content Type

### DIFF
--- a/config/install/core.entity_form_display.node.ucb_article.default.yml
+++ b/config/install/core.entity_form_display.node.ucb_article.default.yml
@@ -5,8 +5,10 @@ dependencies:
     - field.field.node.ucb_article.body
     - field.field.node.ucb_article.field_ucb_article_byline
     - field.field.node.ucb_article.field_ucb_article_categories
+    - field.field.node.ucb_article.field_ucb_article_content
     - field.field.node.ucb_article.field_ucb_article_external_url
     - field.field.node.ucb_article.field_ucb_article_image
+    - field.field.node.ucb_article.field_ucb_article_summary
     - field.field.node.ucb_article.field_ucb_article_tags
     - field.field.node.ucb_article.field_ucb_article_thumbnail
     - node.type.ucb_article
@@ -14,8 +16,8 @@ dependencies:
     - field_group
     - link
     - media_library
+    - paragraphs
     - path
-    - text
 third_party_settings:
   field_group:
     group_tabs:
@@ -25,6 +27,7 @@ third_party_settings:
         - group_tags
         - group_byline
         - group_external_link
+        - group_article_content
       parent_name: ''
       weight: 7
       format_type: tabs
@@ -38,25 +41,25 @@ third_party_settings:
       label: Tabs
     group_images:
       children:
-        - field_ucb_article_image
+        - field_ucb_article_summary
         - field_ucb_article_thumbnail
       parent_name: group_tabs
-      weight: 20
+      weight: 14
       format_type: tab
       region: content
       format_settings:
-        show_empty_fields: false
+        description: 'These items will show in the summary instead of the main content.'
+        formatter: closed
+        required_fields: true
         id: ''
         classes: ''
-        description: ''
-        formatter: open
-        required_fields: true
-      label: Images
+        show_empty_fields: false
+      label: Summary
     group_categories:
       children:
         - field_ucb_article_categories
       parent_name: group_tabs
-      weight: 21
+      weight: 15
       format_type: tab
       region: content
       format_settings:
@@ -71,7 +74,7 @@ third_party_settings:
       children:
         - field_ucb_article_byline
       parent_name: group_tabs
-      weight: 23
+      weight: 17
       format_type: tab
       region: content
       format_settings:
@@ -86,7 +89,7 @@ third_party_settings:
       children:
         - field_ucb_article_tags
       parent_name: group_tabs
-      weight: 22
+      weight: 16
       format_type: tab
       region: content
       format_settings:
@@ -101,7 +104,7 @@ third_party_settings:
       children:
         - field_ucb_article_external_url
       parent_name: group_tabs
-      weight: 24
+      weight: 18
       format_type: tab
       region: content
       format_settings:
@@ -112,21 +115,27 @@ third_party_settings:
         formatter: closed
         required_fields: true
       label: 'External Link'
+    group_article_content:
+      children:
+        - field_ucb_article_content
+        - field_ucb_article_image
+      parent_name: group_tabs
+      weight: 12
+      format_type: tab
+      region: hidden
+      format_settings:
+        description: "Main content area for articles to be added to.\r\nAddition content sections can be added as needed."
+        formatter: open
+        required_fields: true
+        id: ''
+        classes: ''
+        show_empty_fields: false
+      label: 'Article Content'
 id: node.ucb_article.default
 targetEntityType: node
 bundle: ucb_article
 mode: default
 content:
-  body:
-    type: text_textarea_with_summary
-    weight: 6
-    settings:
-      rows: 9
-      summary_rows: 3
-      placeholder: ''
-      show_summary: false
-    third_party_settings: {  }
-    region: content
   created:
     type: datetime_timestamp
     weight: 2
@@ -144,7 +153,7 @@ content:
     type: entity_reference_autocomplete
     region: content
   field_ucb_article_categories:
-    weight: 10
+    weight: 28
     settings:
       match_operator: CONTAINS
       match_limit: 10
@@ -152,6 +161,24 @@ content:
       placeholder: ''
     third_party_settings: {  }
     type: entity_reference_autocomplete
+    region: content
+  field_ucb_article_content:
+    type: paragraphs
+    weight: 26
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+      closed_mode: summary
+      autocollapse: none
+      closed_mode_threshold: 0
+      features:
+        collapse_edit_all: collapse_edit_all
+        duplicate: duplicate
+    third_party_settings: {  }
     region: content
   field_ucb_article_external_url:
     weight: 13
@@ -161,12 +188,13 @@ content:
     third_party_settings: {  }
     type: link_default
     region: content
-  field_ucb_article_image:
-    type: media_library_widget
-    weight: 8
+  field_ucb_article_summary:
+    weight: 27
     settings:
-      media_types: {  }
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
+    type: string_textarea
     region: content
   field_ucb_article_tags:
     weight: 11
@@ -180,7 +208,7 @@ content:
     region: content
   field_ucb_article_thumbnail:
     type: media_library_widget
-    weight: 9
+    weight: 28
     settings:
       media_types: {  }
     third_party_settings: {  }
@@ -224,4 +252,6 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
+  body: true
+  field_ucb_article_image: true
   promote: true

--- a/config/install/core.entity_view_display.node.ucb_article.default.yml
+++ b/config/install/core.entity_view_display.node.ucb_article.default.yml
@@ -5,27 +5,22 @@ dependencies:
     - field.field.node.ucb_article.body
     - field.field.node.ucb_article.field_ucb_article_byline
     - field.field.node.ucb_article.field_ucb_article_categories
+    - field.field.node.ucb_article.field_ucb_article_content
     - field.field.node.ucb_article.field_ucb_article_external_url
     - field.field.node.ucb_article.field_ucb_article_image
+    - field.field.node.ucb_article.field_ucb_article_summary
     - field.field.node.ucb_article.field_ucb_article_tags
     - field.field.node.ucb_article.field_ucb_article_thumbnail
     - node.type.ucb_article
   module:
+    - entity_reference_revisions
     - link
-    - text
     - user
 id: node.ucb_article.default
 targetEntityType: node
 bundle: ucb_article
 mode: default
 content:
-  body:
-    label: hidden
-    type: text_default
-    weight: 101
-    settings: {  }
-    third_party_settings: {  }
-    region: content
   field_ucb_article_byline:
     weight: 106
     label: hidden
@@ -41,6 +36,15 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
+    region: content
+  field_ucb_article_content:
+    type: entity_reference_revisions_entity_view
+    weight: 108
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
     region: content
   field_ucb_article_external_url:
     weight: 107
@@ -62,6 +66,13 @@ content:
       view_mode: original_image
       link: false
     third_party_settings: {  }
+    region: content
+  field_ucb_article_summary:
+    weight: 109
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: basic_string
     region: content
   field_ucb_article_tags:
     weight: 105
@@ -85,4 +96,5 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  body: true

--- a/config/install/core.entity_view_display.node.ucb_article.teaser.yml
+++ b/config/install/core.entity_view_display.node.ucb_article.teaser.yml
@@ -6,36 +6,32 @@ dependencies:
     - field.field.node.ucb_article.body
     - field.field.node.ucb_article.field_ucb_article_byline
     - field.field.node.ucb_article.field_ucb_article_categories
+    - field.field.node.ucb_article.field_ucb_article_content
     - field.field.node.ucb_article.field_ucb_article_external_url
     - field.field.node.ucb_article.field_ucb_article_image
+    - field.field.node.ucb_article.field_ucb_article_summary
     - field.field.node.ucb_article.field_ucb_article_tags
     - field.field.node.ucb_article.field_ucb_article_thumbnail
     - node.type.ucb_article
   module:
-    - text
     - user
 id: node.ucb_article.teaser
 targetEntityType: node
 bundle: ucb_article
 mode: teaser
 content:
-  body:
-    label: hidden
-    type: text_summary_or_trimmed
-    weight: 101
-    settings:
-      trim_length: 600
-    third_party_settings: {  }
-    region: content
   links:
     weight: 100
     settings: {  }
     third_party_settings: {  }
     region: content
 hidden:
+  body: true
   field_ucb_article_byline: true
   field_ucb_article_categories: true
+  field_ucb_article_content: true
   field_ucb_article_external_url: true
   field_ucb_article_image: true
+  field_ucb_article_summary: true
   field_ucb_article_tags: true
   field_ucb_article_thumbnail: true

--- a/config/install/field.field.node.ucb_article.field_ucb_article_content.yml
+++ b/config/install/field.field.node.ucb_article.field_ucb_article_content.yml
@@ -1,0 +1,110 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_article_content
+    - node.type.ucb_article
+    - paragraphs.paragraphs_type.article_content
+    - paragraphs.paragraphs_type.hero_unit
+  module:
+    - entity_reference_revisions
+id: node.ucb_article.field_ucb_article_content
+field_name: field_ucb_article_content
+entity_type: node
+bundle: ucb_article
+label: 'Article Content'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      article_content: article_content
+      hero_unit: hero_unit
+    target_bundles_drag_drop:
+      article_content:
+        enabled: true
+        weight: 28
+      hero_unit:
+        enabled: true
+        weight: 29
+      news_story_accent_row:
+        weight: 30
+        enabled: false
+      news_story_content_row:
+        weight: 31
+        enabled: false
+      single_page_accordion_row:
+        weight: 32
+        enabled: false
+      single_page_bullet_list:
+        weight: 33
+        enabled: false
+      single_page_bullet_list_item:
+        weight: 34
+        enabled: false
+      single_page_content_cards:
+        weight: 35
+        enabled: false
+      single_page_content_feed:
+        weight: 36
+        enabled: false
+      single_page_cta_cards_row:
+        weight: 37
+        enabled: false
+      single_page_cta_icon:
+        weight: 38
+        enabled: false
+      single_page_custom:
+        weight: 39
+        enabled: false
+      single_page_duo_tone_cta:
+        weight: 40
+        enabled: false
+      single_page_hero:
+        weight: 41
+        enabled: false
+      single_page_icon_cards_row:
+        weight: 42
+        enabled: false
+      single_page_icon_cta_row:
+        weight: 43
+        enabled: false
+      single_page_image_slider:
+        weight: 44
+        enabled: false
+      single_page_jumbo_button:
+        weight: 45
+        enabled: false
+      single_page_list:
+        weight: 46
+        enabled: false
+      single_page_list_item:
+        weight: 47
+        enabled: false
+      single_page_page_header:
+        weight: 48
+        enabled: false
+      single_page_section_header:
+        weight: 49
+        enabled: false
+      single_page_success_stories:
+        weight: 50
+        enabled: false
+      single_page_webform:
+        weight: 51
+        enabled: false
+      slider:
+        weight: 52
+        enabled: false
+      slider_image:
+        weight: 53
+        enabled: false
+      text_block:
+        weight: 54
+        enabled: false
+field_type: entity_reference_revisions

--- a/config/install/field.field.node.ucb_article.field_ucb_article_external_url.yml
+++ b/config/install/field.field.node.ucb_article.field_ucb_article_external_url.yml
@@ -11,7 +11,7 @@ field_name: field_ucb_article_external_url
 entity_type: node
 bundle: ucb_article
 label: 'External Link'
-description: 'Add a url to a news/articles on another website.  '
+description: 'Add a url to a news/articles on another website. This article page will then redirect to the specified link.'
 required: false
 translatable: false
 default_value: {  }

--- a/config/install/field.field.node.ucb_article.field_ucb_article_summary.yml
+++ b/config/install/field.field.node.ucb_article.field_ucb_article_summary.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_ucb_article_summary
+    - node.type.ucb_article
+id: node.ucb_article.field_ucb_article_summary
+field_name: field_ucb_article_summary
+entity_type: node
+bundle: ucb_article
+label: 'Article Summary'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/config/install/field.storage.node.field_ucb_article_content.yml
+++ b/config/install/field.storage.node.field_ucb_article_content.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - node
+    - paragraphs
+id: node.field_ucb_article_content
+field_name: field_ucb_article_content
+entity_type: node
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_ucb_article_summary.yml
+++ b/config/install/field.storage.node.field_ucb_article_summary.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_ucb_article_summary
+field_name: field_ucb_article_summary
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/paragraphs.paragraphs_type.article_content.yml
+++ b/config/install/paragraphs.paragraphs_type.article_content.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies: {  }
+id: article_content
+label: 'Article Content'
+icon_uuid: null
+icon_default: null
+description: ''
+behavior_plugins: {  }

--- a/ucb_custom_page_types.info.yml
+++ b/ucb_custom_page_types.info.yml
@@ -20,5 +20,5 @@ dependencies:
   - text
   - ucb_custom_paragraphs
   - user
-version: '1.0.4'
+version: '1.0.5'
 package: 'UCB Custom Page Types'


### PR DESCRIPTION
I have updated the content type for Articles.
This branch has updated yml files that should cover both the content type and the new paragraphs element Article Content
Be sure to use the branch 59 of the base repository to make sure you have the updated yml and css for the Articles content type and paragraph.

Related to issue #59 in the base repo