### PR TITLE
Remove Article Content as choice in Basic Pages

### DIFF
--- a/config/install/field.field.node.page.field_above_body_block.yml
+++ b/config/install/field.field.node.page.field_above_body_block.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.storage.node.field_above_body_block
     - node.type.page
+    - paragraphs.paragraphs_type.article_content
     - paragraphs.paragraphs_type.slider_image
   module:
     - entity_reference_revisions
@@ -22,8 +23,12 @@ settings:
   handler_settings:
     negate: 1
     target_bundles:
+      article_content: article_content
       slider_image: slider_image
     target_bundles_drag_drop:
+      article_content:
+        enabled: true
+        weight: 6
       hero_unit:
         weight: 6
         enabled: false

--- a/config/install/field.field.node.page.field_above_content.yml
+++ b/config/install/field.field.node.page.field_above_content.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.storage.node.field_above_content
     - node.type.page
+    - paragraphs.paragraphs_type.article_content
     - paragraphs.paragraphs_type.slider_image
   module:
     - entity_reference_revisions
@@ -22,8 +23,12 @@ settings:
   handler_settings:
     negate: 1
     target_bundles:
+      article_content: article_content
       slider_image: slider_image
     target_bundles_drag_drop:
+      article_content:
+        enabled: true
+        weight: 6
       hero_unit:
         weight: 5
         enabled: false

--- a/config/install/field.field.node.page.field_below_body_block.yml
+++ b/config/install/field.field.node.page.field_below_body_block.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.storage.node.field_below_body_block
     - node.type.page
+    - paragraphs.paragraphs_type.article_content
     - paragraphs.paragraphs_type.slider_image
   module:
     - entity_reference_revisions
@@ -22,8 +23,12 @@ settings:
   handler_settings:
     negate: 1
     target_bundles:
+      article_content: article_content
       slider_image: slider_image
     target_bundles_drag_drop:
+      article_content:
+        enabled: true
+        weight: 6
       hero_unit:
         weight: 6
         enabled: false

--- a/config/install/field.field.node.page.field_below_content.yml
+++ b/config/install/field.field.node.page.field_below_content.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.storage.node.field_below_content
     - node.type.page
+    - paragraphs.paragraphs_type.article_content
     - paragraphs.paragraphs_type.slider_image
   module:
     - entity_reference_revisions
@@ -22,8 +23,12 @@ settings:
   handler_settings:
     negate: 1
     target_bundles:
+      article_content: article_content
       slider_image: slider_image
     target_bundles_drag_drop:
+      article_content:
+        enabled: true
+        weight: 6
       hero_unit:
         weight: 5
         enabled: false

--- a/config/install/field.field.node.page.field_sidebar.yml
+++ b/config/install/field.field.node.page.field_sidebar.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.storage.node.field_sidebar
     - node.type.page
+    - paragraphs.paragraphs_type.article_content
     - paragraphs.paragraphs_type.slider_image
   module:
     - entity_reference_revisions
@@ -22,8 +23,12 @@ settings:
   handler_settings:
     negate: 1
     target_bundles:
+      article_content: article_content
       slider_image: slider_image
     target_bundles_drag_drop:
+      article_content:
+        enabled: true
+        weight: 6
       hero_unit:
         weight: 6
         enabled: false
@@ -36,7 +41,4 @@ settings:
       text_block:
         weight: 9
         enabled: false
-      ucb_page_body:
-        enabled: true
-        weight: 10
 field_type: entity_reference_revisions

--- a/ucb_custom_page_types.info.yml
+++ b/ucb_custom_page_types.info.yml
@@ -20,5 +20,5 @@ dependencies:
   - text
   - ucb_custom_paragraphs
   - user
-version: '1.0.5'
+version: '1.0.6'
 package: 'UCB Custom Page Types'


### PR DESCRIPTION
Removed option to add article content to basic pages.
These changes affect the above body block, above content, below body block, below content, and sidebar selectors.

Closes #10 